### PR TITLE
Show workflow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "orange-tools"
+version = "0.1"
+description = "Utilities for Orange developers"
+classifiers = [
+    "Development Status :: 2 - Pre-Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Localization",
+    "Programming Language :: Python :: 3",
+]
+dependencies = [
+    "Orange3",
+    "AnyQt",
+    "pyqt6"
+]
+
+[project.scripts]
+show-workflow = "tools.showWorkflow:main"
+stamper = "tools.stamper:main"
+trimshot = "tools.trim:main"
+
+[tool.setuptools]
+packages = {find = {where = ["."]}}

--- a/tools/showWorkflow.py
+++ b/tools/showWorkflow.py
@@ -1,0 +1,75 @@
+import shutil
+import sys
+from xml.dom import minidom
+import base64
+import pickle
+from pprint import pformat
+
+IGNORE = {"savedWidgetGeometry", "controlAreaVisible", "context_settings"}
+
+try:
+    from Orange.widgets.utils.filedialogs import RecentPath
+except ImportError:
+    print("Orange is not installed in this environment")
+
+def main():
+    if len(sys.argv) <= 1:
+        print("""
+show-workflow <file.ows> [--list | widget-type or number]
+
+Show workflow settings for all or selected widget(s).
+
+--list prints widget names and exits
+""")
+    exit()
+
+    fname = sys.argv[1]
+    op = (sys.argv + [None])[2]
+    wf = minidom.parse(fname)
+    node_names = {
+        n.getAttribute("id"): (n.getAttribute("name"), n.getAttribute("qualified_name"))
+        for n in wf.getElementsByTagName("node")}
+
+    if op == "--list":
+        for wid, (name, qname) in node_names.items():
+            print(f"{wid:2}: {name} ({qname})")
+        exit()
+    elif op:
+        op = op.lower()
+
+    for props in wf.getElementsByTagName("properties"):
+        wid = props.getAttribute("node_id")
+        name, qualified = node_names[wid]
+        if op is not None and not (
+                int(wid) == int(op) if op.isdigit()
+                else op in name.lower() or op in qualified.lower()):
+            continue
+        s = f"{wid} {name} ({qualified})"
+        print(s + "\n" + "-" * len(s))
+        format = props.getAttribute("format")
+        child = props.firstChild
+        if format == "pickle":
+            values = pickle.loads(base64.b64decode(child.nodeValue))
+        elif format == "literal":
+            values = eval(child.nodeValue)
+        else:
+            print(f"Unsupported settings format ({format})")
+
+        for name, value in values.items():
+            if name in IGNORE:
+                continue
+            if not isinstance(value, (int, float, bool, str, list, dict, type(None))):
+                valtype = f" ({type(value)})"
+            else:
+                valtype = ""
+            print(f"{name}{valtype}:", end=" " if not value or isinstance(value, (int, float, bool, str)) else "\n  ")
+            print(pformat(value).replace("\n", "\n  "))
+        contexts = values.get("context_settings")
+        if contexts is not None:
+            print("Contexts:")
+            for ctx, context in enumerate(contexts):
+                print(f"{ctx:<2}: " + pformat(context.__dict__).replace("\n", "\n    "))
+        print()
+
+if __name__ == "__main__":
+    main()

--- a/tools/trim.py
+++ b/tools/trim.py
@@ -98,12 +98,17 @@ def process(file_path, args):
     print("   -> thumb: %s.thumb.png, size %s" % (file_name, str(wim.size)))
 
 
-parser = argparse.ArgumentParser()
-parser.add_argument("-n", "--nocrop", help="crop image",
-                    action="store_true", default=False)
-parser.add_argument("-b", "--border", help="border width", default=3)
-parser.add_argument("files", type=str, help="file names to match")
-arguments = parser.parse_args()
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-n", "--nocrop", help="crop image",
+                        action="store_true", default=False)
+    parser.add_argument("-b", "--border", help="border width", default=3)
+    parser.add_argument("files", type=str, help="file names to match")
+    arguments = parser.parse_args()
 
-for f_name in arguments.files.split():
-    process(f_name, arguments)
+    for f_name in arguments.files.split():
+        process(f_name, arguments)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Add showWorkflow.py, which prints out the settings from a workflow. Run as

  `python showWorkflow.py <workflow.ows> [--list | pattern]

  `--list` just lists widget ids, names and qualified names, while pattern shows settings for all widgets that include the given pattern in their name (in the workflow) or their qualified name. Without `--list` or `pattern`, the scripts lists all their widgets and their settings.

- Also, add pyproject.toml so that it's possible to run 

  ```sh
  pip install -e .
  ```

  and get scripts as commands.

  I added just three commands:

  - `trimshot` runs trim.py
  - `stamper` runs stamper.py
  - `show-workflow` runs showWorkflow.py.
  
  All these commands are run from command line, i.e. just `stamper` not `python ...something...`.

  Other commands can easily be added by those who need them. :)

E.g. after "installing" this, settings for (all) scatterplots in untitled.ows can be printed by

```sh
show-workflow untitled.ows scatter
```